### PR TITLE
Fix document creation

### DIFF
--- a/xdp-document.c
+++ b/xdp-document.c
@@ -151,7 +151,8 @@ xdp_document_new (GomRepository *repo,
 {
   return g_object_new (XDP_TYPE_DOCUMENT,
                        "repository", repo,
-                       "uri", uri);
+                       "uri", uri,
+                       NULL);
 }
 
 gint64


### PR DESCRIPTION
There was a missing NULL termination for varargs that got
in the way of creating XdpDocument instances.
