### PR TITLE
Wip: Add OpenDocument call

### DIFF
--- a/org.freedesktop.portal.documents.xml
+++ b/org.freedesktop.portal.documents.xml
@@ -25,6 +25,10 @@
 
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <interface name='org.freedesktop.portal.DocumentPortal'>
+    <method name="OpenDocument">
+      <arg type='s' name='type' direction='in'/>
+      <arg type='x' name='handle' direction='out'/>
+    </method>
   </interface>
   <interface name='org.freedesktop.portal.Document'>
     <method name="Read">

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -660,3 +660,32 @@ xdp_document_load (GomRepository      *repository,
         load->pending = g_list_append (load->pending, g_object_ref (task));
     }
 }
+
+XdpDocument *
+xdp_document_for_uri (GomRepository *repo,
+                      const char *uri,
+                      GError **error)
+{
+  GHashTableIter iter;
+  XdpDocument *doc;
+
+  ensure_documents ();
+
+  g_hash_table_iter_init (&iter, documents);
+  while (g_hash_table_iter_next (&iter, NULL, (gpointer *)&doc))
+    {
+      if (strcmp (uri, doc->uri) == 0)
+        return g_object_ref (doc);
+    }
+
+  doc = xdp_document_new (repo, uri);
+  if (!gom_resource_save_sync (GOM_RESOURCE (doc), error))
+    {
+      g_object_unref (doc);
+      return NULL;
+    }
+
+  g_hash_table_insert (documents, &doc->id, g_object_ref (doc));
+
+  return doc;
+}

--- a/xdp-document.h
+++ b/xdp-document.h
@@ -13,6 +13,10 @@ G_DECLARE_FINAL_TYPE(XdpDocument, xdp_document, XDP, DOCUMENT, GomResource);
 XdpDocument *xdp_document_new (GomRepository *repo,
                                const char *uri);
 
+XdpDocument *xdp_document_for_uri (GomRepository *repo,
+                                   const char *uri,
+                                   GError **error);
+
 gint64 xdp_document_get_id (XdpDocument *doc);
 
 XdpPermissionFlags xdp_document_get_permissions (XdpDocument *doc,

--- a/xdp-main.c
+++ b/xdp-main.c
@@ -371,12 +371,11 @@ content_chooser_done (GObject *object,
   if (uri[strlen (uri) - 1] == '\n')
     uri[strlen (uri) - 1] = '\0';
 
-  doc = xdp_document_new (repository, uri);
-  if (!gom_resource_save_sync (GOM_RESOURCE (doc), &error))
+  doc = xdp_document_for_uri (repository, uri, &error);
+  if (doc == NULL)
     {
-      g_dbus_method_invocation_return_error (data->invocation, XDP_ERROR, XDP_ERROR_FAILED, "failed to save: %s", error->message);
-      g_object_unref (doc);
-      return;
+       g_dbus_method_invocation_return_error (data->invocation, XDP_ERROR, XDP_ERROR_FAILED, "failed to store: %s", error->message);
+       return;
     }
 
   /* TODO set permissions */


### PR DESCRIPTION
This call spawns a content chooser (currently just zenity), and
returns an id for the chosen document to the caller.

Still missing: set permissions for the caller.
