### PR TITLE
Fix memory handling

### DIFF
--- a/xdp-document.c
+++ b/xdp-document.c
@@ -565,7 +565,10 @@ document_load_abort (DocumentLoad *load, GError *error)
   for (l = load->pending; l != NULL; l = l->next)
     {
       GTask *task = l->data;
-      g_task_return_error (task, error);
+      if (error)
+        g_task_return_new_error (task, error->domain, error->code, error->message);
+      else
+        g_task_return_new_error (task, XDP_ERROR, XDP_ERROR_FAILED, "Loading document failed");
     }
   g_hash_table_remove (loads, &load->id);
 }

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -181,6 +181,30 @@ xdp_document_get_permissions (XdpDocument *doc,
   return flags;
 }
 
+void
+xdp_document_grant_permissions (XdpDocument *doc,
+                                const char *app_id,
+                                XdpPermissionFlags perms)
+{
+  XdpPermissions *permissions = NULL;
+  XdpPermissionFlags old_perms;
+  GomRepository *repo;
+
+  old_perms = xdp_document_get_permissions (doc, app_id);
+  if ((perms & old_perms) == perms)
+    return;
+
+  g_object_get (doc, "repository", &repo, NULL);
+  permissions = xdp_permissions_new (repo, doc, app_id, perms, FALSE);
+  if (!gom_resource_save_sync (GOM_RESOURCE (permissions), NULL))
+    {
+      g_object_unref (permissions);
+      return;
+    }
+  doc->permissions = g_list_prepend (doc->permissions, permissions);
+  gom_resource_save_sync (GOM_RESOURCE (doc), NULL);
+}
+
 gboolean
 xdp_document_has_permissions (XdpDocument *doc,
                               const char *app_id,
@@ -428,6 +452,48 @@ xdp_document_handle_finish_update (XdpDocument *doc,
   document_update_free (update);
 }
 
+static void
+xdp_document_handle_grant_permissions (XdpDocument *doc,
+                                       GDBusMethodInvocation *invocation,
+                                       const char *app_id,
+                                       GVariant *parameters)
+{
+  const char *target_app_id;
+  char **permissions;
+  XdpPermissionFlags perms;
+  gint i;
+
+  g_variant_get (parameters, "(sas)", &target_app_id, &permissions);
+
+  if (!xdp_document_has_permissions (doc, app_id, XDP_PERMISSION_FLAGS_GRANT_PERMISSIONS))
+    {
+      g_dbus_method_invocation_return_error (invocation, XDP_ERROR, XDP_ERROR_FAILED,
+                                             "No permissions to grant permissions");
+      return;
+    }
+
+  perms = 0;
+  for (i = 0; permissions[i]; i++)
+    {
+      if (strcmp (permissions[i], "read") == 0)
+        perms |= XDP_PERMISSION_FLAGS_READ;
+      else if (strcmp (permissions[i], "write") == 0)
+        perms |= XDP_PERMISSION_FLAGS_WRITE;
+      else if (strcmp (permissions[i], "grant-permissions") == 0)
+        perms |= XDP_PERMISSION_FLAGS_GRANT_PERMISSIONS;
+      else
+        {
+          g_dbus_method_invocation_return_error (invocation, XDP_ERROR, XDP_ERROR_FAILED,
+                                                 "No such permission: %s", permissions[i]);
+          return;
+        }
+    }
+
+  xdp_document_grant_permissions (doc, target_app_id, perms);
+
+  g_dbus_method_invocation_return_value (invocation, g_variant_new ("()"));
+}
+
 struct {
   const char *name;
   const char *args;
@@ -438,7 +504,8 @@ struct {
 } doc_methods[] = {
   { "Read", "(s)", xdp_document_handle_read},
   { "PrepareUpdate", "(ssas)", xdp_document_handle_prepare_update},
-  { "FinishUpdate", "(su)", xdp_document_handle_finish_update}
+  { "FinishUpdate", "(su)", xdp_document_handle_finish_update},
+  { "GrantPermissions", "(sas)", xdp_document_handle_grant_permissions}
 };
 
 void

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -151,7 +151,8 @@ xdp_document_new (GomRepository *repo,
 {
   return g_object_new (XDP_TYPE_DOCUMENT,
                        "repository", repo,
-                       "uri", uri);
+                       "uri", uri,
+                       NULL);
 }
 
 gint64

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -463,7 +463,7 @@ xdp_document_handle_grant_permissions (XdpDocument *doc,
   XdpPermissionFlags perms;
   gint i;
 
-  g_variant_get (parameters, "(sas)", &target_app_id, &permissions);
+  g_variant_get (parameters, "(&s^a&s)", &target_app_id, &permissions);
 
   if (!xdp_document_has_permissions (doc, app_id, XDP_PERMISSION_FLAGS_GRANT_PERMISSIONS))
     {

--- a/xdp-document.h
+++ b/xdp-document.h
@@ -17,6 +17,9 @@ gint64 xdp_document_get_id (XdpDocument *doc);
 
 XdpPermissionFlags xdp_document_get_permissions (XdpDocument *doc,
                                                  const char *app_id);
+void xdp_document_grant_permissions (XdpDocument *doc,
+                                     const char *app_id,
+                                     XdpPermissionFlags perms);
 
 void xdp_document_handle_call (XdpDocument *doc,
                                GDBusMethodInvocation *invocation,

--- a/xdp-enums.h
+++ b/xdp-enums.h
@@ -6,9 +6,9 @@
 G_BEGIN_DECLS
 
 typedef enum {
-  XDP_PERMISSION_FLAGS_READ              = (1<<0),
-  XDP_PERMISSION_FLAGS_WRITE             = (1<<1),
-  XDP_PERMISSION_FLAGS_GRANT_PERMISSION  = (1<<2),
+  XDP_PERMISSION_FLAGS_READ               = (1<<0),
+  XDP_PERMISSION_FLAGS_WRITE              = (1<<1),
+  XDP_PERMISSION_FLAGS_GRANT_PERMISSIONS  = (1<<2),
 
   XDP_PERMISSION_FLAGS_ALL               = ((1<<3) - 1)
 } XdpPermissionFlags;


### PR DESCRIPTION
g_task_return_error consumes the passed GError, so calling it in a loop with the same error is not a good idea. This was crashing when running xdp-cat 9999 a few times in a row.
