### PR TITLE
Take the right bus name

### DIFF
--- a/xdp-main.c
+++ b/xdp-main.c
@@ -456,7 +456,7 @@ main (int    argc,
   introspection_data = g_dbus_node_info_new_for_xml (g_bytes_get_data (introspection_bytes, NULL), NULL);
 
   owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
-                             "org.freedesktop.portal.DocumentsPortal",
+                             "org.freedesktop.portal.DocumentPortal",
                              G_BUS_NAME_OWNER_FLAGS_NONE,
                              on_bus_acquired,
                              on_name_acquired,


### PR DESCRIPTION
We use DocumentPortal, singular, everywhere, but the one place
where we take the bus name. Fix it to match the name we have
in the service file.
