### PR TITLE
Ensure app ids in all the places

### DIFF
--- a/xdp-util.c
+++ b/xdp-util.c
@@ -171,6 +171,8 @@ name_owner_changed (GDBusConnection *connection,
   const char *name, *from, *to;
   g_variant_get (parameters, "(sss)", &name, &from, &to);
 
+  ensure_app_ids ();
+
   if (name[0] == ':' &&
       strcmp (name, from) == 0 &&
       strcmp (to, "") == 0)


### PR DESCRIPTION
When I split out the app-id tracking code, I moved the
ensure_app_ids() call from main to the functions where
this hash table is used. But I forgot one, leading to

g_hash_table_lookup: assertion 'hash_table != NULL' failed

criticals.
