### PR TITLE
Use the right bus name in utilities

### DIFF
--- a/xdp-add.c
+++ b/xdp-add.c
@@ -41,7 +41,7 @@ main (int    argc,
     }
 
   ret = g_dbus_connection_call_sync (bus,
-                                     "org.freedesktop.portal.DocumentsPortal",
+                                     "org.freedesktop.portal.DocumentPortal",
                                      "/org/freedesktop/portal/document",
                                      "org.freedesktop.portal.DocumentPortal",
                                      "Add",
@@ -66,7 +66,7 @@ main (int    argc,
   path = g_strdup_printf ("/org/freedesktop/portal/document/%ld", handle);
 
   ret = g_dbus_connection_call_sync (bus,
-                                     "org.freedesktop.portal.DocumentsPortal",
+                                     "org.freedesktop.portal.DocumentPortal",
                                      path,
                                      "org.freedesktop.portal.Document",
                                      "GrantPermissions",

--- a/xdp-cat.c
+++ b/xdp-cat.c
@@ -74,7 +74,7 @@ main (int    argc,
   path = g_build_filename ("/org/freedesktop/portal/document", argv[1], NULL);
   proxy = xdp_dbus_document_proxy_new_sync (bus,
                                             G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
-                                            "org.freedesktop.portal.DocumentsPortal",
+                                            "org.freedesktop.portal.DocumentPortal",
                                             path,
                                             NULL, &error);
   if (proxy == NULL)

--- a/xdp-update.c
+++ b/xdp-update.c
@@ -83,7 +83,7 @@ main (int    argc,
   path = g_build_filename ("/org/freedesktop/portal/document", argv[1], NULL);
   proxy = xdp_dbus_document_proxy_new_sync (bus,
                                             G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES | G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
-                                            "org.freedesktop.portal.DocumentsPortal",
+                                            "org.freedesktop.portal.DocumentPortal",
                                             path,
                                             NULL, &error);
   if (proxy == NULL)


### PR DESCRIPTION
The utilities where still using the wrong bus name.
Update them to use org.freedesktop.portal.DocumentPortal.
