### PR TITLE
Filter attributes in GetInfo

### DIFF
--- a/xdp-document.c
+++ b/xdp-document.c
@@ -652,6 +652,22 @@ xdp_document_handle_get_info (XdpDocument *doc,
   GString *s = NULL;
   g_autofree char *attrs = NULL;
   gint i;
+  const gchar * const allowed_attributes[] = {
+    "standard::name",
+    "standard::display-name",
+    "standard::icon",
+    "standard::symbolic-icon",
+    "standard::content-type",
+    "standard::size",
+    "etag::value",
+    "thumbnail::path"
+    "thumbnail::failed",
+    "thumbnail::is-valid",
+    "preview::icon",
+    "access::can-read",
+    "access::can-write",
+    NULL
+  };
 
   g_variant_get (parameters, "(&s^a&s)", &window, &attributes);
 
@@ -665,6 +681,14 @@ xdp_document_handle_get_info (XdpDocument *doc,
   s = g_string_new ("");
   for (i = 0; attributes[i]; i++)
     {
+      if (!g_strv_contains (allowed_attributes, attributes[i]))
+        {
+          g_string_free (s, TRUE);
+          g_dbus_method_invocation_return_error (invocation, XDP_ERROR, XDP_ERROR_FAILED,
+                                                 "Not an allowed attribute: %s", attributes[i]);
+          return;
+        }
+
       if (i > 0)
         g_string_append_c (s, ',');
       g_string_append (s, attributes[i]);

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -560,13 +560,20 @@ xdp_document_handle_grant_permissions (XdpDocument *doc,
   xdp_document_grant_permissions (doc, target_app_id, perms, NULL, permissions_granted, g_object_ref (invocation));
 }
 
+typedef struct {
+  GDBusMethodInvocation *invocation;
+  XdpPermissionFlags permissions;
+} InfoData;
+
 static void
 get_info_cb (GObject *source_object,
              GAsyncResult *result,
              gpointer data)
 {
   GFile *file = G_FILE (source_object);
-  GDBusMethodInvocation *invocation = data;
+  g_autofree InfoData *info_data = data;
+  GDBusMethodInvocation *invocation = info_data->invocation;
+  XdpPermissionFlags permissions = info_data->permissions;
   g_autoptr (GFileInfo) info = NULL;
   g_autoptr (GError) error = NULL;
   GVariant *parameters;
@@ -634,6 +641,22 @@ get_info_cb (GObject *source_object,
           continue;
         }
 
+      if (strcmp (attributes[i], "access::can-read") == 0)
+        {
+          gboolean b = g_variant_get_boolean (v);
+
+          g_variant_unref (v);
+          v = g_variant_new_boolean (b && ((permissions & XDP_PERMISSION_FLAGS_READ) != 0));
+        }
+      else if (strcmp (attributes[i], "access::can-write") == 0)
+        {
+          gboolean b = g_variant_get_boolean (v);
+
+          g_variant_unref (v);
+          v = g_variant_new_boolean (b && ((permissions & XDP_PERMISSION_FLAGS_WRITE) != 0));
+        }
+
+
       g_variant_builder_add (&builder, "{sv}", attributes[i], v);
     }
 
@@ -664,6 +687,7 @@ xdp_document_handle_get_info (XdpDocument *doc,
     "access::can-write",
     NULL
   };
+  InfoData *data;
 
   g_variant_get (parameters, "(&s^a&s)", &window, &attributes);
 
@@ -693,12 +717,16 @@ xdp_document_handle_get_info (XdpDocument *doc,
 
   file = g_file_new_for_uri (doc->uri);
 
+  data = g_new (InfoData, 1);
+  data->invocation = invocation;
+  data->permissions = xdp_document_get_permissions (doc, app_id);
+
   g_file_query_info_async (file, attrs,
                            G_FILE_QUERY_INFO_NONE,
                            G_PRIORITY_DEFAULT,
                            NULL,
                            get_info_cb,
-                           invocation);
+                           data);
 }
 
 struct {

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -660,10 +660,6 @@ xdp_document_handle_get_info (XdpDocument *doc,
     "standard::content-type",
     "standard::size",
     "etag::value",
-    "thumbnail::path"
-    "thumbnail::failed",
-    "thumbnail::is-valid",
-    "preview::icon",
     "access::can-read",
     "access::can-write",
     NULL


### PR DESCRIPTION
Filter attributes we allow to avoid leaking any detailed data from the system
that is not necessarily part of the document per-se, such as exact modification
times, filesystem or device ids or xattrs.

Anything that you can get from just reading the file is ok, like file size,
mime type and thumbnail info.

There are also some things that are implied with the user allowing access to the
file, such as file name and icons.

A few less obvious things are needed to a good UI. This includes the etag, and
access rights.

Some things need sorting out here still, such as:
- Do we expose thumbnails as paths ?
- Can we sent a preview over the bus ?
