### PR TITLE
Drop window arguments

### DIFF
--- a/org.freedesktop.portal.documents.xml
+++ b/org.freedesktop.portal.documents.xml
@@ -37,23 +37,19 @@
   </interface>
   <interface name='org.freedesktop.portal.Document'>
     <method name="Read">
-      <arg type='s' name='window' direction='in'/>
       <arg type='h' name='fd' direction='out'/>
     </method>
     <method name="GetInfo">
-      <arg type='s' name='window' direction='in'/>
       <arg type='as' name='attributes' direction='in'/>
       <arg type='a{sv}' name='info' direction='out'/>
     </method>
     <method name="PrepareUpdate">
-      <arg type='s' name='window' direction='in'/>
       <arg type='s' name='etag' direction='in'/>
       <arg type='as' name='flags' direction='in'/>
       <arg type='u' name='id' direction='out'/>
       <arg type='h' name='fd' direction='out'/>
     </method>
     <method name="FinishUpdate">
-      <arg type='s' name='window' direction='in'/>
       <arg type='u' name='id' direction='in'/>
     </method>
     <method name="GrantPermissions">

--- a/xdp-cat.c
+++ b/xdp-cat.c
@@ -13,7 +13,6 @@
 
 gboolean
 xdp_dbus_document_call_read_with_unix_fd_list_sync (XdpDbusDocument *proxy,
-                                                    const gchar     *arg_window,
                                                     GUnixFDList    **out_fd_list,
                                                     GVariant       **out_fd,
                                                     GCancellable    *cancellable,
@@ -22,7 +21,7 @@ xdp_dbus_document_call_read_with_unix_fd_list_sync (XdpDbusDocument *proxy,
   GVariant *_ret;
   _ret = g_dbus_proxy_call_with_unix_fd_list_sync (G_DBUS_PROXY (proxy),
                                                    "Read",
-                                                   g_variant_new ("(s)", arg_window),
+                                                   g_variant_new ("()"),
                                                    G_DBUS_CALL_FLAGS_NONE,
                                                    -1,
                                                    NULL,
@@ -84,7 +83,7 @@ main (int    argc,
     }
 
   fd_list = g_unix_fd_list_new ();
-  if (!xdp_dbus_document_call_read_with_unix_fd_list_sync (proxy, "foo", &fd_list, &fd_v, NULL, &error))
+  if (!xdp_dbus_document_call_read_with_unix_fd_list_sync (proxy, &fd_list, &fd_v, NULL, &error))
     {
       g_printerr ("%s\n", error->message);
       return 1;

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -302,15 +302,12 @@ xdp_document_handle_read (XdpDocument *doc,
                           const char *app_id,
                           GVariant *parameters)
 {
-  const char *window;
   g_autoptr(GFile) file = NULL;
   g_autofree char *path = NULL;
   GUnixFDList *fd_list = NULL;
   g_autoptr(GError) error = NULL;
   int fd, fd_id;
   GVariant *retval;
-
-  g_variant_get (parameters, "(&s)", &window);
 
   if (!xdp_document_has_permissions (doc, app_id, XDP_PERMISSION_FLAGS_READ))
     {
@@ -370,7 +367,7 @@ xdp_document_handle_prepare_update (XdpDocument *doc,
                                     const char *app_id,
                                     GVariant *parameters)
 {
-  const char *window, *etag, **flags;
+  const char *etag, **flags;
   g_autoptr(GFile) file = NULL;
   g_autofree char *path = NULL;
   g_autofree char *dir = NULL;
@@ -382,7 +379,7 @@ xdp_document_handle_prepare_update (XdpDocument *doc,
   GVariant *retval;
   XdpDocumentUpdate *update;
 
-  g_variant_get (parameters, "(&s&s^a&s)", &window, &etag, &flags);
+  g_variant_get (parameters, "(&s^a&s)", &etag, &flags);
 
   if (!xdp_document_has_permissions (doc, app_id, XDP_PERMISSION_FLAGS_WRITE))
     {
@@ -487,7 +484,6 @@ xdp_document_handle_finish_update (XdpDocument *doc,
                                    const char *app_id,
                                    GVariant *parameters)
 {
-  const char *window;
   guint32 id;
   g_autoptr(GError) error = NULL;
   g_autoptr(GFile) dir = NULL;
@@ -499,7 +495,7 @@ xdp_document_handle_finish_update (XdpDocument *doc,
   char buffer[8192];
   GList *l;
 
-  g_variant_get (parameters, "(&su)", &window, &id);
+  g_variant_get (parameters, "(u)", &id);
 
   if (!xdp_document_has_permissions (doc, app_id, XDP_PERMISSION_FLAGS_WRITE))
     {
@@ -699,7 +695,6 @@ get_info_cb (GObject *source_object,
   g_autoptr (GFileInfo) info = NULL;
   g_autoptr (GError) error = NULL;
   GVariant *parameters;
-  const char *window;
   const char **attributes;
   GVariantBuilder builder;
   gint i;
@@ -712,7 +707,7 @@ get_info_cb (GObject *source_object,
     }
 
   parameters = g_dbus_method_invocation_get_parameters (invocation);
-  g_variant_get (parameters, "(&s^a&s)", &window, &attributes);
+  g_variant_get (parameters, "(^a&s)", &attributes);
 
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
   for (i = 0; attributes[i]; i++)
@@ -791,7 +786,6 @@ xdp_document_handle_get_info (XdpDocument *doc,
                               const char *app_id,
                               GVariant *parameters)
 {
-  const char *window;
   const char **attributes;
   g_autoptr (GFile) file = NULL;
   GString *s = NULL;
@@ -811,7 +805,7 @@ xdp_document_handle_get_info (XdpDocument *doc,
   };
   InfoData *data;
 
-  g_variant_get (parameters, "(&s^a&s)", &window, &attributes);
+  g_variant_get (parameters, "(^a&s)", &attributes);
 
   if (!xdp_document_has_permissions (doc, app_id, XDP_PERMISSION_FLAGS_READ))
     {

--- a/xdp-update.c
+++ b/xdp-update.c
@@ -14,7 +14,6 @@
 
 gboolean
 xdp_dbus_document_call_prepare_update_with_unix_fd_list_sync (XdpDbusDocument *proxy,
-                                                              const gchar     *arg_window,
                                                               const gchar     *arg_etag,
                                                               gchar          **arg_flags,
                                                               guint32         *out_id,
@@ -27,8 +26,7 @@ xdp_dbus_document_call_prepare_update_with_unix_fd_list_sync (XdpDbusDocument *p
 
   _ret = g_dbus_proxy_call_with_unix_fd_list_sync (G_DBUS_PROXY (proxy),
                                                    "PrepareUpdate",
-                                                   g_variant_new ("(ss^as)",
-                                                                  arg_window,
+                                                   g_variant_new ("(s^as)",
                                                                   arg_etag,
                                                                   arg_flags),
                                                    G_DBUS_CALL_FLAGS_NONE,
@@ -93,7 +91,7 @@ main (int    argc,
     }
 
   fd_list = g_unix_fd_list_new ();
-  if (!xdp_dbus_document_call_prepare_update_with_unix_fd_list_sync (proxy, "foo", "", flags, &id, &fd_list, &fd_v, NULL, &error))
+  if (!xdp_dbus_document_call_prepare_update_with_unix_fd_list_sync (proxy, "", flags, &id, &fd_list, &fd_v, NULL, &error))
     {
       g_printerr ("%s\n", error->message);
       return 1;
@@ -144,7 +142,7 @@ main (int    argc,
   g_object_unref (fd_list);
 
 
-  if (!xdp_dbus_document_call_finish_update_sync (proxy, "foo", id, NULL, &error))
+  if (!xdp_dbus_document_call_finish_update_sync (proxy, id, NULL, &error))
     {
       g_printerr ("%s\n", error->message);
       return 1;


### PR DESCRIPTION
It seems better to keep the document portal a UI-less
service that just handles handle<>fd translation. If
errors need to be reported to the user, we can use
the app id to find name, icon, etc to represent the
app at fault.

We don't have window ids for Wayland surfaces, anyway.
