### PR TITLE
Make parallel permission revocations work

### DIFF
--- a/org.freedesktop.portal.documents.xml
+++ b/org.freedesktop.portal.documents.xml
@@ -34,6 +34,9 @@
       <arg type='s' name='title' direction='in'/>
       <arg type='x' name='handle' direction='out'/>
     </method>
+    <method name="Remove">
+      <arg type='x' name='handle' direction='in'/>
+    </method>
   </interface>
   <interface name='org.freedesktop.portal.Document'>
     <method name="Read">

--- a/xdp-document.h
+++ b/xdp-document.h
@@ -67,6 +67,15 @@ xdp_document_for_uri_and_title (GomRepository      *repository,
                                 GAsyncReadyCallback callback,
                                 gpointer            user_data);
 
+void xdp_document_remove (GomRepository       *repository,
+                          gint64               id,
+                          GCancellable        *cancellable,
+                          GAsyncReadyCallback  callback,
+                          gpointer             user_data);
+gboolean xdp_document_remove_finish (GomRepository  *repository,
+                                     GAsyncResult   *result,
+                                     GError        **error);
+
 G_END_DECLS
 
 #endif /* XDP_DOCUMENT_H */

--- a/xdp-main.c
+++ b/xdp-main.c
@@ -235,6 +235,46 @@ portal_new (GDBusMethodInvocation *invocation,
   xdp_document_for_uri_and_title (repository, uri, title, NULL, got_document_for_uri_cb, g_object_ref (invocation));
 }
 
+static void
+document_removed (GObject *source,
+                  GAsyncResult *result,
+                  gpointer data)
+{
+  GomRepository *repository = GOM_REPOSITORY (source);
+  GDBusMethodInvocation *invocation = data;
+  g_autoptr (GError) error = NULL;
+
+  if (!xdp_document_remove_finish (repository, result, &error))
+    g_dbus_method_invocation_return_error (invocation,
+                                           XDP_ERROR, XDP_ERROR_FAILED,
+                                           "%s", error->message);
+  else
+    g_dbus_method_invocation_return_value (invocation, g_variant_new ("()"));
+}
+
+static void
+portal_remove (GDBusMethodInvocation *invocation,
+               const char *app_id)
+{
+  GVariant *parameters;
+  gint64 handle;
+
+  if (app_id[0] != '\0')
+    {
+      /* don't allow this from within the sandbox for now */
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDP_ERROR, XDP_ERROR_FAILED,
+                                             "Not allowed inside sandbox");
+      return;
+    }
+
+  parameters = g_dbus_method_invocation_get_parameters (invocation);
+  g_variant_get (parameters, "(x)", &handle);
+
+  xdp_document_remove (repository, handle, NULL, document_removed, invocation);
+}
+
+
 typedef void (*PortalMethod) (GDBusMethodInvocation *invocation,
                               const char *app_id);
 
@@ -279,6 +319,18 @@ handle_new_method (XdpDbusDocumentPortal *portal,
   return TRUE;
 }
 
+static gboolean
+handle_remove_method (XdpDbusDocumentPortal *portal,
+                      GDBusMethodInvocation *invocation,
+                      const char            *base_uri,
+                      const char            *title,
+                      gpointer               callback)
+{
+  xdp_invocation_lookup_app_id (invocation, NULL, got_app_id_cb, portal_remove);
+
+  return TRUE;
+}
+
 static void
 on_bus_acquired (GDBusConnection *connection,
                  const gchar     *name,
@@ -292,6 +344,7 @@ on_bus_acquired (GDBusConnection *connection,
 
   g_signal_connect (helper, "handle-add", G_CALLBACK (handle_add_method), NULL);
   g_signal_connect (helper, "handle-new", G_CALLBACK (handle_new_method), NULL);
+  g_signal_connect (helper, "handle-remove", G_CALLBACK (handle_remove_method), NULL);
 
   xdp_connection_track_name_owners (connection);
 


### PR DESCRIPTION
Keep a list of pending permission revocations for each document,
and deal with parallel revocations of the same permissions.
