### PR TITLE
Simplify deletion

### DIFF
--- a/org.freedesktop.portal.documents.xml
+++ b/org.freedesktop.portal.documents.xml
@@ -64,5 +64,7 @@
     <method name="RevokePermissions">
       <arg type='x' name='cookie' direction='in'/>
     </method>
+    <method name="Delete">
+    </method>
   </interface>
 </node>

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -940,6 +940,14 @@ xdp_document_handle_delete (XdpDocument *doc,
   g_autoptr (GomResourceGroup) group = NULL;
   GList *l;
 
+  if (doc->updates != NULL)
+    {
+      g_dbus_method_invocation_return_error (invocation,
+                                             XDP_ERROR, XDP_ERROR_FAILED,
+                                             "Document has active updates");
+      return;
+    }
+
   g_object_get (doc, "repository", &repository, NULL);
   group = gom_resource_group_new (repository);
   gom_resource_group_append (group, GOM_RESOURCE (doc));

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -66,6 +66,8 @@ xdp_document_finalize (GObject *object)
   g_free (doc->uri);
   g_free (doc->title);
 
+  g_list_free_full (doc->permissions, g_object_unref);
+
   G_OBJECT_CLASS (xdp_document_parent_class)->finalize (object);
 }
 

--- a/xdp-document.c
+++ b/xdp-document.c
@@ -64,6 +64,7 @@ xdp_document_finalize (GObject *object)
   XdpDocument *doc = (XdpDocument *)object;
 
   g_free (doc->uri);
+  g_free (doc->title);
 
   G_OBJECT_CLASS (xdp_document_parent_class)->finalize (object);
 }


### PR DESCRIPTION
Instead of queueing up deletions of individual permission objects,
just assume that the db removal will always work, and return right
away. This changes the behaviour for parallel revocations so that
only the first one will succeed, and all later RevokePermissions
calls for the same handle will return an error.
