### PR TITLE
Add support for transient documents and permissions

### DIFF
--- a/org.freedesktop.portal.documents.xml
+++ b/org.freedesktop.portal.documents.xml
@@ -27,15 +27,18 @@
   <interface name='org.freedesktop.portal.DocumentPortal'>
     <method name="Add">
       <arg type='s' name='uri' direction='in'/>
+      <arg type='b' name='transient' direction='in'/>
       <arg type='x' name='handle' direction='out'/>
     </method>
     <method name="AddLocal">
       <arg type='h' name='fd' direction='in'/>
+      <arg type='b' name='transient' direction='in'/>
       <arg type='x' name='handle' direction='out'/>
     </method>
     <method name="New">
       <arg type='s' name='base_uri' direction='in'/>
       <arg type='s' name='title' direction='in'/>
+      <arg type='b' name='transient' direction='in'/>
       <arg type='x' name='handle' direction='out'/>
     </method>
   </interface>
@@ -59,6 +62,7 @@
     <method name="GrantPermissions">
       <arg type='s' name='appid' direction='in'/>
       <arg type='as' name='permissions' direction='in'/>
+      <arg type='b' name='transient' direction='in'/>
       <arg type='x' name='cookie' direction='out'/>
     </method>
     <method name="RevokePermissions">

--- a/xdp-add-local.c
+++ b/xdp-add-local.c
@@ -25,12 +25,20 @@ do_add_local (int argc, char *argv[])
   g_autofree char *dbus_path = NULL;
   int fd, fd_id;
   char *permissions[4] = { "read", "write", "grant-permissions", NULL };
+  gboolean transient = FALSE;
 
   setlocale (LC_ALL, "");
 
-  if (argc < 1)
+  if (argc > 0 && g_strcmp0 (argv[0], "--transient") == 0)
     {
-      g_printerr ("Usage: xdp add FILE [APPID]\n");
+      transient = TRUE;
+      argv += 1;
+      argc -= 1;
+    }
+
+  if (argc < 1 || argc > 2)
+    {
+      g_printerr ("Usage: xdp add-local [--transient] FILE [APPID]\n");
       return 1;
     }
 
@@ -69,7 +77,7 @@ do_add_local (int argc, char *argv[])
                                                        "/org/freedesktop/portal/document",
                                                        "org.freedesktop.portal.DocumentPortal",
                                                        "AddLocal",
-                                                       g_variant_new ("(h)", fd_id),
+                                                       g_variant_new ("(hb)", fd_id, transient),
                                                        G_VARIANT_TYPE ("(x)"),
                                                        G_DBUS_CALL_FLAGS_NONE,
                                                        30000,
@@ -99,7 +107,7 @@ do_add_local (int argc, char *argv[])
                                          dbus_path,
                                          "org.freedesktop.portal.Document",
                                          "GrantPermissions",
-                                         g_variant_new ("(s^as)", appid, permissions),
+                                         g_variant_new ("(s^asb)", appid, permissions, transient),
                                          G_VARIANT_TYPE ("(x)"),
                                          G_DBUS_CALL_FLAGS_NONE,
                                          30000,

--- a/xdp-add.c
+++ b/xdp-add.c
@@ -17,12 +17,20 @@ do_add (int argc, char *argv[])
   GVariant *ret;
   g_autofree char *path = NULL;
   char *permissions[4] = { "read", "write", "grant-permissions", NULL };
+  gboolean transient = FALSE;
 
   setlocale (LC_ALL, "");
 
-  if (argc < 1)
+  if (argc> 0 && g_strcmp0 (argv[0], "--transient") == 0)
     {
-      g_printerr ("Usage: xdp add FILE [APPID]\n");
+      transient = TRUE;
+      argv += 1;
+      argc -= 1;
+    }
+
+  if (argc < 1 || argc > 2)
+    {
+      g_printerr ("Usage: xdp add [--transient] FILE [APPID]\n");
       return 1;
     }
 
@@ -43,7 +51,7 @@ do_add (int argc, char *argv[])
                                      "/org/freedesktop/portal/document",
                                      "org.freedesktop.portal.DocumentPortal",
                                      "Add",
-                                     g_variant_new ("(s)", uri),
+                                     g_variant_new ("(sb)", uri, transient),
                                      G_VARIANT_TYPE ("(x)"),
                                      G_DBUS_CALL_FLAGS_NONE,
                                      30000,
@@ -70,7 +78,7 @@ do_add (int argc, char *argv[])
                                          path,
                                          "org.freedesktop.portal.Document",
                                          "GrantPermissions",
-                                         g_variant_new ("(s^as)", appid, permissions),
+                                         g_variant_new ("(s^asb)", appid, permissions, transient),
                                          G_VARIANT_TYPE ("(x)"),
                                          G_DBUS_CALL_FLAGS_NONE,
                                          30000,

--- a/xdp-document.h
+++ b/xdp-document.h
@@ -11,10 +11,12 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(XdpDocument, xdp_document, XDP, DOCUMENT, GomResource);
 
 XdpDocument *xdp_document_new (GomRepository *repo,
-                               const char *uri);
+                               const char *uri,
+                               gboolean transient);
 XdpDocument *xdp_document_new_with_title (GomRepository *repo,
                                           const char *base_uri,
-                                          const char *title);
+                                          const char *title,
+                                          gboolean transient);
 
 gint64 xdp_document_get_id (XdpDocument *doc);
 
@@ -23,6 +25,7 @@ XdpPermissionFlags xdp_document_get_permissions (XdpDocument *doc,
 void xdp_document_grant_permissions (XdpDocument *doc,
                                      const char *app_id,
                                      XdpPermissionFlags perms,
+                                     gboolean transient,
                                      GCancellable       *cancellable,
                                      GAsyncReadyCallback callback,
                                      gpointer            user_data);
@@ -52,6 +55,7 @@ XdpDocument * xdg_document_load_finish (GomRepository *repository,
                                         GError         **error);
 void xdp_document_for_uri (GomRepository      *repository,
                            const char         *uri,
+                           gboolean            transient,
                            GCancellable       *cancellable,
                            GAsyncReadyCallback callback,
                            gpointer            user_data);
@@ -63,6 +67,7 @@ void
 xdp_document_for_uri_and_title (GomRepository      *repository,
                                 const char         *uri,
                                 const char         *title,
+                                gboolean            transient,
                                 GCancellable       *cancellable,
                                 GAsyncReadyCallback callback,
                                 gpointer            user_data);

--- a/xdp-new.c
+++ b/xdp-new.c
@@ -18,12 +18,20 @@ do_new (int argc, char **argv)
   GVariant *ret;
   g_autofree char *path = NULL;
   char *permissions[4] = { "read", "write", "grant-permissions", NULL };
+  gboolean transient = FALSE;
 
   setlocale (LC_ALL, "");
 
+  if (argc > 0 && g_strcmp0 (argv[0], "--transient") == 0)
+    {
+      transient = TRUE;
+      argv += 1;
+      argc -= 1;
+    }
+
   if (argc != 3)
     {
-      g_printerr ("Usage: xdp new URI TITLE APPID\n");
+      g_printerr ("Usage: xdp new [--transient] URI TITLE APPID\n");
       return 1;
     }
 
@@ -44,7 +52,7 @@ do_new (int argc, char **argv)
                                      "/org/freedesktop/portal/document",
                                      "org.freedesktop.portal.DocumentPortal",
                                      "New",
-                                     g_variant_new ("(ss)", uri, title),
+                                     g_variant_new ("(ssb)", uri, title, transient),
                                      G_VARIANT_TYPE ("(x)"),
                                      G_DBUS_CALL_FLAGS_NONE,
                                      30000,
@@ -69,7 +77,7 @@ do_new (int argc, char **argv)
                                      path,
                                      "org.freedesktop.portal.Document",
                                      "GrantPermissions",
-                                     g_variant_new ("(s^as)", appid, permissions),
+                                     g_variant_new ("(s^asb)", appid, permissions, transient),
                                      G_VARIANT_TYPE ("(x)"),
                                      G_DBUS_CALL_FLAGS_NONE,
                                      30000,

--- a/xdp-permissions.c
+++ b/xdp-permissions.c
@@ -182,6 +182,8 @@ xdp_permissions_init (XdpPermissions *self)
 {
 }
 
+static gint64 transients = G_MAXINT64;
+
 XdpPermissions *
 xdp_permissions_new (GomRepository *repo,
                      XdpDocument *doc,
@@ -195,6 +197,7 @@ xdp_permissions_new (GomRepository *repo,
                        "document", xdp_document_get_id (doc),
                        "permissions", (guint)permissions,
                        "transient", transient,
+                       "id", transient ? transients-- : 0,
                        NULL);
 }
 


### PR DESCRIPTION
Transient means that these objects are not saved to the
database, so they will disappear when the session ends.
We give transient objects IDs which start at the high
end of the range.
